### PR TITLE
Update appid due to build error

### DIFF
--- a/application.fam
+++ b/application.fam
@@ -1,5 +1,5 @@
 App(
-    appid="LoRA_Terminal",
+    appid="lora_terminal",
     name="LoRA_Terminal",
     apptype=FlipperAppType.EXTERNAL,
     entry_point="uart_terminal_app",


### PR DESCRIPTION
Update the application.fam appid to match the regular expression ^[a-z0-9_]+$

Fixes error -- fbt: warning: Failed parsing manifest 'C:\repos\flipper\official-dev-fork\applications_user\lora_terminal\application.fam' : Invalid appid 'LoRA_Terminal'. Must match regex 're.compile('^[a-z0-9_]+$')'      
